### PR TITLE
Fix directory creation for MCP stdio mode

### DIFF
--- a/lib/headless_browser_tool/directory_setup.rb
+++ b/lib/headless_browser_tool/directory_setup.rb
@@ -4,7 +4,7 @@ require "fileutils"
 
 module HeadlessBrowserTool
   module DirectorySetup
-    HBT_DIR = "./.hbt"
+    HBT_DIR = File.expand_path("~/.hbt")
     SCREENSHOTS_DIR = File.join(HBT_DIR, "screenshots").freeze
     SESSIONS_DIR = File.join(HBT_DIR, "sessions").freeze
     LOGS_DIR = File.join(HBT_DIR, "logs").freeze


### PR DESCRIPTION
## Problem
When launched via MCP stdio mode, the current directory may be read-only (e.g., Claude launches from `/`). The gem was trying to create `.hbt` in the current directory, causing: `Read-only file system @ dir_s_mkdir - ./.hbt`

## Solution
Changed from `./.hbt` to `~/.hbt` so the gem always uses the user's home directory regardless of where it's launched from.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>